### PR TITLE
Write --noproxy to .curlrc (SLE12 GA)

### DIFF
--- a/package/yast2-proxy.changes
+++ b/package/yast2-proxy.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr  9 15:35:53 UTC 2015 - mvidner@suse.com
+
+- Write also --noproxy to .curlrc otherwise it is ignored even if
+  set in the environment (bsc#923788).
+- 3.1.2.1
+
+-------------------------------------------------------------------
 Wed Oct  8 13:47:41 UTC 2014 - mvidner@suse.com
 
 - Fixed Test Proxy Settings always reporting failure (bnc#853725,

--- a/package/yast2-proxy.spec
+++ b/package/yast2-proxy.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-proxy
-Version:        3.1.2
+Version:        3.1.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Proxy.rb
+++ b/src/modules/Proxy.rb
@@ -117,37 +117,16 @@ module Yast
       true
     end
 
-    # Write routing settings and apply changes
-    # @return true if success
-    def Write
-      Builtins.y2milestone("Writing configuration")
-      if !@modified
-        Builtins.y2milestone(
-          "No changes to proxy configuration -> nothing to write"
-        )
-        return true
-      end
-
-      steps = [_("Update proxy configuration")]
-
-      caption = _("Saving Proxy Configuration")
-      # sleep for longer time, so that progress does not disappear right afterwards
-      # but only when Progress is visible
-      sl = Progress.status == true ? 500 : 0
-
-      Progress.New(caption, " ", Builtins.size(steps), steps, [], "")
-
-      Progress.NextStage
-      Progress.Title(_("Updating proxy configuration..."))
-
-      # Update /etc/sysconfig/proxy
+    def WriteSysconfig
       SCR.Write(path(".sysconfig.proxy.PROXY_ENABLED"), @enabled ? "yes" : "no")
       SCR.Write(path(".sysconfig.proxy.HTTP_PROXY"), @http)
       SCR.Write(path(".sysconfig.proxy.HTTPS_PROXY"), @https)
       SCR.Write(path(".sysconfig.proxy.FTP_PROXY"), @ftp)
       SCR.Write(path(".sysconfig.proxy.NO_PROXY"), @no)
       SCR.Write(path(".sysconfig.proxy"), nil)
+    end
 
+    def WriteCurlrc
       # proxy is used, write /root/.curlrc
       # bugzilla #305163
       if @enabled
@@ -200,6 +179,35 @@ module Yast
       end
 
       SCR.Write(path(".root.curlrc"), nil)
+    end
+
+    # Write proxy settings and apply changes
+    # @return true if success
+    def Write
+      Builtins.y2milestone("Writing configuration")
+      if !@modified
+        Builtins.y2milestone(
+          "No changes to proxy configuration -> nothing to write"
+        )
+        return true
+      end
+
+      steps = [_("Update proxy configuration")]
+
+      caption = _("Saving Proxy Configuration")
+      # sleep for longer time, so that progress does not disappear right afterwards
+      # but only when Progress is visible
+      sl = Progress.status == true ? 500 : 0
+
+      Progress.New(caption, " ", Builtins.size(steps), steps, [], "")
+
+      Progress.NextStage
+      Progress.Title(_("Updating proxy configuration..."))
+
+      # Update /etc/sysconfig/proxy
+      WriteSysconfig()
+
+      WriteCurlrc()
       Builtins.sleep(sl)
       Progress.NextStage
 

--- a/src/modules/Proxy.rb
+++ b/src/modules/Proxy.rb
@@ -144,7 +144,9 @@ module Yast
       options = {
         "--proxy-user" => proxyuser,
         # bnc#305163
-        "--proxy" =>      @http
+        "--proxy" =>      @http,
+        # bsc#923788
+        "--noproxy" =>    @no
       }
 
       # proxy is used, write /root/.curlrc

--- a/src/modules/Proxy.rb
+++ b/src/modules/Proxy.rb
@@ -144,9 +144,9 @@ module Yast
       options = {
         "--proxy-user" => proxyuser,
         # bnc#305163
-        "--proxy" =>      @http,
+        "--proxy"      => @http,
         # bsc#923788
-        "--noproxy" =>    @no
+        "--noproxy"    => @no
       }
 
       # proxy is used, write /root/.curlrc

--- a/src/modules/Proxy.rb
+++ b/src/modules/Proxy.rb
@@ -129,6 +129,7 @@ module Yast
     # Escape backslash characters in .curlrc (bnc#331038)
     # see also http://curl.haxx.se/docs/manpage.html#-K for escaping rules
     def EscapeForCurlrc(s)
+      return nil if s.nil?
       Builtins.mergestring(Builtins.splitstring(s, "\\"),
                            "\\\\")
     end
@@ -136,7 +137,6 @@ module Yast
     def WriteCurlrc
       proxyuser = nil
       if @user != ""
-        @user = EscapeForCurlrc(@user)
         proxyuser = @user
         proxyuser = @user + ":" + @pass if @pass != ""
       end
@@ -156,7 +156,7 @@ module Yast
         options.each do |option, value|
           value = nil if value == ""
 
-          SCR.Write(path(".root.curlrc") + option, value)
+          SCR.Write(path(".root.curlrc") + option, EscapeForCurlrc(value))
 
           if value != nil && write_comment
             SCR.Write(path(".root.curlrc") + option + "comment",

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,6 @@
 TESTS = \
-  test_proxy_return_code_test.rb
+  test_proxy_return_code_test.rb \
+  write_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec --format doc

--- a/test/matchers.rb
+++ b/test/matchers.rb
@@ -1,0 +1,40 @@
+require "rspec"
+require "yast"
+
+module Yast
+  module RSpec
+    # RSpec extension to add YaST-specific matchers
+    module Matchers
+      # Matches arguments of type YaST::Path whose string representation matches
+      # the provided regular expression
+      #
+      # @example
+      #   expect(Yast::SCR).to receive(:Read).with(path_matching(/^\.sysconfig\.nfs/))
+      def path_matching(match)
+        PathMatchingMatcher.new(match)
+      end
+
+      # @private
+      class PathMatchingMatcher
+        def initialize(expected)
+          @expected = Regexp.new(expected)
+        end
+
+        # RSpec 3 uses === while RSpec 2 uses ==
+        # Thus, implementing just == should work with both
+        def ==(other)
+          return false unless other.is_a?(Yast::Path)
+          other.to_s =~ @expected ? true : false
+        end
+
+        def description
+          "path_matching(#{@expected.inspect})"
+        end
+
+        def inspect
+          description
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,11 @@ srcdir = File.expand_path("../../src", __FILE__)
 y2dirs = ENV.fetch("Y2DIR", "").split(":")
 ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 
-require "yast/rspec"
+require_relative "matchers"
+RSpec.configure do |c|
+  c.include Yast::RSpec::Matchers
+end
+
+def path(s)
+  Yast::Path.new(s)
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
 srcdir = File.expand_path("../../src", __FILE__)
 y2dirs = ENV.fetch("Y2DIR", "").split(":")
 ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
+
+require "yast/rspec"

--- a/test/write_test.rb
+++ b/test/write_test.rb
@@ -22,7 +22,7 @@ describe "Yast::ProxyClass" do
     end
 
     it "writes proxy settings, and a comment, when proxy is enabled" do
-      subject.Import({ "enabled" =>    true,
+      subject.Import({ "enabled"    => true,
                        "http_proxy" => "proxy.example.org:3128" })
 
       expect(Yast::SCR).to receive(:Write).
@@ -49,9 +49,9 @@ describe "Yast::ProxyClass" do
     end
 
     it "writes a no-proxy setting" do
-      subject.Import({ "enabled" =>    true,
+      subject.Import({ "enabled"    => true,
                        "http_proxy" => "proxy.example.org:3128",
-                       "no_proxy" =>   "example.org,example.com,localhost" })
+                       "no_proxy"   => "example.org,example.com,localhost" })
       expect(Yast::SCR).to receive(:Write).
         with(path(".root.curlrc.\"--noproxy\""),
              "example.org,example.com,localhost").
@@ -65,9 +65,9 @@ describe "Yast::ProxyClass" do
     end
 
     it "escapes user name" do
-      subject.Import({ "enabled" =>        true,
-                       "http_proxy" =>     "proxy.example.org:3128",
-                       "proxy_user" =>     "User\\Domain",
+      subject.Import({ "enabled"        => true,
+                       "http_proxy"     => "proxy.example.org:3128",
+                       "proxy_user"     => "User\\Domain",
                        "proxy_password" => "P" })
 
       expect(Yast::SCR).to receive(:Write).

--- a/test/write_test.rb
+++ b/test/write_test.rb
@@ -33,6 +33,10 @@ describe "Yast::ProxyClass" do
         with(path(".root.curlrc.\"--proxy\""), "proxy.example.org:3128").
         once.and_return true
 
+      expect(Yast::SCR).to receive(:Write).
+        with(path(".root.curlrc.\"--noproxy\""), "localhost").
+        once.and_return true
+
       allow(Yast::SCR).to receive(:Write).
         with(path_matching(/^\.root\.curlrc/), nil).
         and_return true
@@ -40,6 +44,22 @@ describe "Yast::ProxyClass" do
       expect(Yast::SCR).to receive(:Write).
         with(path(".root.curlrc"), nil).
         once.and_return true
+
+      expect(subject.WriteCurlrc).to be true
+    end
+
+    it "writes a no-proxy setting" do
+      subject.Import({ "enabled" =>    true,
+                       "http_proxy" => "proxy.example.org:3128",
+                       "no_proxy" =>   "example.org,example.com,localhost" })
+      expect(Yast::SCR).to receive(:Write).
+        with(path(".root.curlrc.\"--noproxy\""),
+             "example.org,example.com,localhost").
+        once.and_return true
+
+      allow(Yast::SCR).to receive(:Write).
+        with(path_matching(/^\.root\.curlrc/), anything).
+        and_return true
 
       expect(subject.WriteCurlrc).to be true
     end

--- a/test/write_test.rb
+++ b/test/write_test.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env rspec
+require_relative "test_helper"
+require "yast"
+
+Yast.import "Proxy"
+
+describe "Yast::ProxyClass" do
+  subject do
+    Yast::Proxy
+  end
+
+  describe "#WriteCurlrc" do
+    it "deletes proxy entries, when proxy is disabled" do
+      subject.Import({"enabled" => false})
+
+      expect(Yast::SCR).to receive(:Write).
+        with(path_matching(/^\.root\.curlrc/), nil).
+        at_least(:once).
+        and_return true
+
+      expect(subject.WriteCurlrc).to be true
+    end
+
+    it "writes proxy settings, and a comment, when proxy is enabled" do
+      subject.Import({ "enabled" =>    true,
+                       "http_proxy" => "proxy.example.org:3128" })
+
+      expect(Yast::SCR).to receive(:Write).
+        with(path_matching(/^\.root\.curlrc\..*\."comment"/), /Changed/).
+        once.and_return true
+
+      expect(Yast::SCR).to receive(:Write).
+        with(path(".root.curlrc.\"--proxy\""), "proxy.example.org:3128").
+        once.and_return true
+
+      allow(Yast::SCR).to receive(:Write).
+        with(path_matching(/^\.root\.curlrc/), nil).
+        and_return true
+
+      expect(Yast::SCR).to receive(:Write).
+        with(path(".root.curlrc"), nil).
+        once.and_return true
+
+      expect(subject.WriteCurlrc).to be true
+    end
+
+    it "escapes user name" do
+      subject.Import({ "enabled" =>        true,
+                       "http_proxy" =>     "proxy.example.org:3128",
+                       "proxy_user" =>     "User\\Domain",
+                       "proxy_password" => "P" })
+
+      expect(Yast::SCR).to receive(:Write).
+        with(path(".root.curlrc.\"--proxy-user\""), "User\\\\Domain:P").
+        once.and_return true
+
+      allow(Yast::SCR).to receive(:Write).
+        with(path_matching(/^\.root\.curlrc/), anything).
+        and_return true
+
+      expect(subject.WriteCurlrc).to be true
+    end
+  end
+end


### PR DESCRIPTION
A port of https://github.com/yast/yast-network/pull/293

https://bugzilla.suse.com/show_bug.cgi?id=923788
https://trello.com/c/dUtdKuNg/86-3-11-sp3-l3-923788-curlrc-is-missing-noproxy-setting