### PR TITLE
Fix which buttons are displayed in firstboot stage

### DIFF
--- a/package/yast2-proxy.changes
+++ b/package/yast2-proxy.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  4 13:49:19 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix 'proxy' behaviour when running in firstboot (bsc#1140199).
+- 4.0.3
+
+-------------------------------------------------------------------
 Wed Jun 27 17:14:44 CEST 2018 - schubi@suse.de
 
 - Added additional searchkeys to desktop file (fate#321043).

--- a/package/yast2-proxy.spec
+++ b/package/yast2-proxy.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-proxy
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/proxy/dialogs.rb
+++ b/src/include/proxy/dialogs.rb
@@ -376,7 +376,7 @@ module Yast
     # If modified, ask for confirmation
     # @return true if abort is confirmed
     def ReallyAbortCond
-      !modified || Popup.ReallyAbort(true)
+      (!modified || installation?) || Popup.ReallyAbort(true)
     end
 
     # Proxy dialog
@@ -541,11 +541,9 @@ module Yast
         contents,
         help,
         Label.BackButton,
-        Label.FinishButton
+        Label.NextButton
       )
-      Wizard.SetNextButton(:next, Label.OKButton)
-      Wizard.SetAbortButton(:abort, Label.CancelButton)
-      Wizard.HideBackButton
+      adjust_wizard_buttons unless installation?
 
       # #103841, relaxed. now avoiding only quotes
       # #337048 allow using space as well
@@ -751,6 +749,25 @@ module Yast
       end
 
       deep_copy(ret)
+    end
+
+  private
+
+    # Sets OK/Cancel wizard buttons
+    def adjust_wizard_buttons
+      Wizard.SetNextButton(:next, Label.OKButton)
+      Wizard.SetAbortButton(:abort, Label.CancelButton)
+      Wizard.HideBackButton
+    end
+
+    # Determines whether running in installation mode
+    #
+    # We do not use Stage.initial because of firstboot, which which runs in 'installation' mode
+    # but in 'firstboot' stage.
+    #
+    # @return [Boolean] Boolean if running in installation or update mode
+    def installation?
+      Mode.installation || Mode.update
     end
   end
 end

--- a/src/lib/proxy/client.rb
+++ b/src/lib/proxy/client.rb
@@ -149,7 +149,6 @@ module Yast
 
       Wizard.CreateDialog
       Wizard.SetDesktopTitleAndIcon("proxy")
-      Wizard.SetNextButton(:next, Label.FinishButton)
 
       # main ui function
       ret = ProxyMainDialog(true)


### PR DESCRIPTION
Fix which buttons should be displayed when running in installation/firstboot. With the old behavior, it was simply not possible to back.

This problem was observed while debugging the [original bug report](https://bugzilla.suse.com/show_bug.cgi?id=1140199), related to yast2-ntp-client and yast2-network.

## Normal

![screenshot-proxy](https://user-images.githubusercontent.com/15836/60671831-e7d9a300-9e6b-11e9-86e5-c4301e2f984d.png)

## Firstboot

![screenshot-proxy-firstboot](https://user-images.githubusercontent.com/15836/60671697-9204fb00-9e6b-11e9-8f4c-e52b75a66a5d.png)
