### PR TITLE
Added flag to determine if the config should be written to the target system

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 350
+  Max: 355
 
 # Offense count: 8
 Metrics/CyclomaticComplexity:

--- a/package/yast2-proxy.changes
+++ b/package/yast2-proxy.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jun  9 08:04:48 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Added 'to_target' variable which will determine whether the
+  configuration should be written to the target system at the end
+  of the installation or not (bsc#1185016).
+- 4.3.3
+
+-------------------------------------------------------------------
 Mon Aug 10 16:55:44 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(proxy) into the spec file

--- a/package/yast2-proxy.spec
+++ b/package/yast2-proxy.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-proxy
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        YaST2 - Proxy Configuration
 License:        GPL-2.0-or-later

--- a/src/modules/Proxy.rb
+++ b/src/modules/Proxy.rb
@@ -5,7 +5,6 @@ module Yast
   # Configures FTP and HTTP proxies via sysconfig
   # and /root/.curlrc (for YOU)
   class ProxyClass < Module
-
     # @return [Boolan] Whether the configuration should be copied to the target system
     attr_accessor :to_target
 

--- a/src/modules/Proxy.rb
+++ b/src/modules/Proxy.rb
@@ -14,6 +14,7 @@ module Yast
       Yast.import "Summary"
       Yast.import "Progress"
       Yast.import "Mode"
+      Yast.import "Stage"
       Yast.import "Popup"
 
       @proposal_valid = false
@@ -213,6 +214,7 @@ module Yast
 
       # user can't relogin in installation and update, do not show the msg then (bnc#486037, bnc#543469)
       ProxyFinishPopup(true) if Mode.normal
+      @to_target = true if Stage.initial
 
       @modified = false
 

--- a/src/modules/Proxy.rb
+++ b/src/modules/Proxy.rb
@@ -5,6 +5,10 @@ module Yast
   # Configures FTP and HTTP proxies via sysconfig
   # and /root/.curlrc (for YOU)
   class ProxyClass < Module
+
+    # @return [Boolan] Whether the configuration should be copied to the target system
+    attr_accessor :to_target
+
     def main
       textdomain "proxy"
 
@@ -26,6 +30,7 @@ module Yast
       @no = ""
       @user = ""
       @pass = ""
+      @to_target = false
     end
 
     # domains that should not be proxied; reader

--- a/src/modules/Proxy.rb
+++ b/src/modules/Proxy.rb
@@ -5,7 +5,7 @@ module Yast
   # Configures FTP and HTTP proxies via sysconfig
   # and /root/.curlrc (for YOU)
   class ProxyClass < Module
-    # @return [Boolan] Whether the configuration should be copied to the target system
+    # @return [Boolean] Whether the configuration should be copied to the target system
     attr_accessor :to_target
 
     def main


### PR DESCRIPTION
## Problem

During installation or **autoinstallation**, the proxy configuration is written to the the **inst-sys** and then we have to decide if we should copy or write these settings to the target system or not. 

## Solution

The decision is currently made in case that the proxy configuration is given through **linuxrc** but it is ignored in case we are using only AutoYaST. So, two main options came to my mind.

**1. Maintain the current check and force the use of **proxy** linuxrc parameter in case of AutoYaST.**

**2. Add a flag which will determine if we should write the config to the target system or not**

Originally I checked if the variables that exported as environment variables were empty or not but in case that the configuration is read then the defaults could already had set the **no_domains** variable.

In this PR we have gone for option **2**

see https://github.com/yast/yast-installation/pull/965 && https://github.com/yast/yast-network/pull/1231 && https://github.com/yast/yast-autoinstallation/pull/767